### PR TITLE
Add instance crop support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+
+## MotorDataModule instance-crop training
+
+The data module can optionally construct datasets that crop patches
+centered on each annotated motor instance. Enable this behaviour with the
+`use_instance_crop` flag and control the number of crops per instance and
+the amount of extra background crops with `num_crops` and `neg_ratio`.
+
+Example:
+
+```python
+from motor_det.data.module import MotorDataModule
+
+dm = MotorDataModule(
+    data_root="data",
+    fold=0,
+    batch_size=2,
+    use_instance_crop=True,
+    num_crops=3,
+    neg_ratio=0.5,
+)
+```
+
+When enabled the module uses `MotorInstanceCropDataset` for positive
+patches and optionally concatenates `BackgroundRandomCropDataset` for
+additional negative examples.


### PR DESCRIPTION
## Summary
- allow `MotorDataModule` to optionally use `MotorInstanceCropDataset`
- add `BackgroundRandomCropDataset`
- include new flags: `use_instance_crop`, `neg_ratio`, `num_crops`
- document how to enable instance-crop training

## Testing
- `python -m py_compile motor_det/data/dataset.py motor_det/data/module.py`
- `pytest -q` *(fails: command not found)*