### PR TITLE
Add positive only crop option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,6 @@ pip install -e .
 Run the training script:
 
 ```bash
-python -m motor_det.engine.train --data_root data --batch_size 2 --epochs 10 --lr 3e-4
+python -m motor_det.engine.train --data_root data --batch_size 2 --epochs 10 \
+    --lr 3e-4 [--positive_only]
 ```

--- a/motor_det/data/module.py
+++ b/motor_det/data/module.py
@@ -3,7 +3,10 @@ import torch
 import numpy as np
 from torch.utils.data import DataLoader, ConcatDataset
 from pathlib import Path
-from motor_det.data.dataset import MotorTrainDataset
+from motor_det.data.dataset import (
+    MotorTrainDataset,
+    PositiveOnlyCropDataset,
+)
 from motor_det.utils.collate import collate_with_centers
 from motor_det.utils.voxel import voxel_spacing_map, read_train_centers
 from sklearn.model_selection import StratifiedGroupKFold
@@ -17,6 +20,7 @@ class MotorDataModule(L.LightningDataModule):
         batch_size: int = 2,
         num_workers: int = 4,
         persistent_workers: bool = False,
+        positive_only: bool = False,
     ):
         super().__init__()
         self.root = Path(data_root)
@@ -24,6 +28,7 @@ class MotorDataModule(L.LightningDataModule):
         self.bs = batch_size
         self.nw = num_workers
         self.persistent_workers = persistent_workers
+        self.positive_only = bool(positive_only)
 
     def setup(self, stage=None):
         # spacing map 과 train centers 데이터프레임 읽기
@@ -69,14 +74,19 @@ class MotorDataModule(L.LightningDataModule):
             # `Motor axis 0` 이 음수이면 해당 tomogram 에 motor 가 없음
             sub_df = sub_df[sub_df["Motor axis 0"] >= 0]
 
-            if len(sub_df) == 0:
+            centers = sub_df[["Motor axis 2", "Motor axis 1", "Motor axis 0"]].values.astype(np.float32)
+            vx = spacing_map.get(tid, 15.0)
+
+            if self.positive_only and len(centers) == 0:
                 # skip tomograms without GT when using positive-only crops
                 continue
-            
-            centers = sub_df[["Motor axis 2", "Motor axis 1", "Motor axis 0"]]
-            centers = centers.values.astype(np.float32)
-            vx = spacing_map.get(tid, 15.0)
-            datasets.append(MotorTrainDataset(zarr_path, centers, vx))
+
+            if self.positive_only:
+                ds = PositiveOnlyCropDataset(zarr_path, centers, vx)
+            else:
+                ds = MotorTrainDataset(zarr_path, centers, vx)
+
+            datasets.append(ds)
 
         if len(datasets) == 0:
             raise ValueError(f"Fold {self.fold}에 사용 가능한 Zarr 데이터가 없습니다: ids={ids}")

--- a/motor_det/engine/train.py
+++ b/motor_det/engine/train.py
@@ -27,6 +27,7 @@ def parse_args():
     p.add_argument("--lr", type=float, default=3e-4)
     p.add_argument("--weight_decay", type=float, default=1e-4)
     p.add_argument("--fold", type=int, default=0)
+    p.add_argument("--positive_only", action="store_true")
     p.add_argument("--gpus", type=int, default=1)
     return p.parse_args()
 
@@ -40,6 +41,7 @@ def main():
         fold=args.fold,
         batch_size=args.batch_size,
         num_workers=4,
+        positive_only=args.positive_only,
     )
     dm.setup()
 


### PR DESCRIPTION
## Summary
- allow training with positive-only crops via a new data module flag
- update training runner to accept `--positive_only`
- document the option in README

## Testing
- `python -m py_compile motor_det/data/module.py motor_det/engine/train.py`