### PR TITLE
Add progressive resizing support

### DIFF
--- a/motor_det/callbacks/freeze_backbone.py
+++ b/motor_det/callbacks/freeze_backbone.py
@@ -1,0 +1,18 @@
+from lightning.pytorch.callbacks import Callback
+
+class FreezeBackbone(Callback):
+    """Freeze backbone for first ``freeze_epochs`` epochs."""
+
+    def __init__(self, freeze_epochs: int = 0):
+        self.freeze_epochs = int(freeze_epochs)
+
+    def on_train_start(self, trainer, pl_module):
+        if self.freeze_epochs > 0:
+            for p in pl_module.net.backbone.parameters():
+                p.requires_grad = False
+
+    def on_train_epoch_end(self, trainer, pl_module, unused=None):
+        if trainer.current_epoch + 1 == self.freeze_epochs:
+            for p in pl_module.net.backbone.parameters():
+                p.requires_grad = True
+

--- a/motor_det/engine/train.py
+++ b/motor_det/engine/train.py
@@ -17,6 +17,7 @@ import torch
 
 from motor_det.data.module import MotorDataModule
 from motor_det.engine.lit_module import LitMotorDet
+from motor_det.callbacks.freeze_backbone import FreezeBackbone
 
 
 def parse_args():
@@ -29,6 +30,12 @@ def parse_args():
     p.add_argument("--fold", type=int, default=0)
     p.add_argument("--positive_only", action="store_true")
     p.add_argument("--gpus", type=int, default=1)
+    p.add_argument("--train_depth_window_size", type=int, default=96)
+    p.add_argument("--train_spatial_window_size", type=int, default=128)
+    p.add_argument("--valid_depth_window_size", type=int, default=192)
+    p.add_argument("--valid_spatial_window_size", type=int, default=128)
+    p.add_argument("--transfer_weights", type=str, default=None)
+    p.add_argument("--freeze_backbone_epochs", type=int, default=0)
     return p.parse_args()
 
 
@@ -42,6 +49,16 @@ def main():
         batch_size=args.batch_size,
         num_workers=4,
         positive_only=args.positive_only,
+        train_crop_size=(
+            args.train_depth_window_size,
+            args.train_spatial_window_size,
+            args.train_spatial_window_size,
+        ),
+        valid_crop_size=(
+            args.valid_depth_window_size,
+            args.valid_spatial_window_size,
+            args.valid_spatial_window_size,
+        ),
     )
     dm.setup()
 
@@ -52,7 +69,16 @@ def main():
         total_steps=len(dm.train_dataloader()) * args.epochs,
     )
 
+    if args.transfer_weights:
+        ckpt = torch.load(args.transfer_weights, map_location="cpu")
+        state_dict = ckpt.get("state_dict", ckpt)
+        model.load_state_dict(state_dict, strict=False)
+
     # -------- Trainer --------
+    callbacks = []
+    if args.freeze_backbone_epochs > 0:
+        callbacks.append(FreezeBackbone(args.freeze_backbone_epochs))
+
     trainer = L.Trainer(
         max_epochs=args.epochs,
         accelerator="gpu" if args.gpus else "cpu",
@@ -60,6 +86,7 @@ def main():
         precision="16-mixed",          # 사용할 AMP 정밀도
         log_every_n_steps=50,
         default_root_dir=Path("runs") / f"motor_fold{args.fold}",
+        callbacks=callbacks,
     )
 
     trainer.fit(model, datamodule=dm)


### PR DESCRIPTION
## Summary
- expose crop sizes for progressive resizing via `MotorDataModule`
- allow loading pre-trained weights and freezing the backbone
- provide CLI options for progressive resizing in `train.py`
- add `FreezeBackbone` callback

## Testing
- `python motor_det/tests/test_quick_train.py` *(fails: ModuleNotFoundError: No module named 'lightning')*