### PR TITLE
Fix torch compile runtime errors

### DIFF
--- a/motor_det/engine/lit_module.py
+++ b/motor_det/engine/lit_module.py
@@ -29,6 +29,8 @@ class LitMotorDet(L.LightningModule):
 
         net = MotorDetNet()
         if hasattr(torch, "compile"):
+            import torch._dynamo
+            torch._dynamo.config.suppress_errors = True
             try:
                 net = torch.compile(net)
             except Exception:


### PR DESCRIPTION
## Summary
- suppress TorchDynamo errors so the model falls back to eager mode

## Testing
- `python -m motor_det.tests.test_quick_train` *(fails: ModuleNotFoundError: No module named 'lightning')*