### PR TITLE
Fix Lightning batch size warning

### DIFF
--- a/motor_det/engine/lit_module.py
+++ b/motor_det/engine/lit_module.py
@@ -47,7 +47,9 @@ class LitMotorDet(L.LightningModule):
         preds = self(batch["image"])
         loss, logs = motor_detection_loss(preds, batch)
         logs = {f"{stage}/{k}": v for k, v in logs.items()}
-        self.log_dict(logs, prog_bar=True, on_step=True, on_epoch=True)
+        batch_size = batch["image"].size(0)
+        self.log_dict(logs, prog_bar=True, on_step=True, on_epoch=True,
+                      batch_size=batch_size)
         return loss
 
     def training_step(self, batch, _):


### PR DESCRIPTION
## Summary
- specify batch size when logging in `LitMotorDet._shared_step`

## Testing
- `python -m py_compile motor_det/engine/lit_module.py`
