### PR TITLE
Add voxel spacing handling

### DIFF
--- a/motor_det/data/dataset.py
+++ b/motor_det/data/dataset.py
@@ -25,10 +25,11 @@ class MotorTrainDataset(Dataset):
     BYU Motor – 학습용 랜덤 Crop + Flip 증강 (Lazy Zarr I/O 버전)
 
     반환 dict:
-      image     : FloatTensor [1, D, H, W]
-      cls       : FloatTensor [1, D/2, H/2, W/2]    ← 이미 채널축 포함
-      offset    : FloatTensor [3, D/2, H/2, W/2]
-      centers_Å : FloatTensor [K, 3]  (가변 길이)
+      image               : FloatTensor [1, D, H, W]
+      cls                 : FloatTensor [1, D/2, H/2, W/2]    ← 이미 채널축 포함
+      offset              : FloatTensor [3, D/2, H/2, W/2]
+      centers_Å           : FloatTensor [K, 3]  (가변 길이)
+      spacing_Å_per_voxel : float
     """
 
     def __init__(
@@ -137,6 +138,7 @@ class MotorTrainDataset(Dataset):
             "cls": cls_map_t,
             "offset": off_map_t,
             "centers_Å": centers_A,
+            "spacing_Å_per_voxel": self.spacing,
         }
 
 
@@ -240,6 +242,7 @@ class MotorInstanceCropDataset(Dataset):
             "cls": cls_map_t,
             "offset": off_map_t,
             "centers_Å": centers_A,
+            "spacing_Å_per_voxel": self.spacing,
         }
     
 class PositiveOnlyCropDataset(MotorInstanceCropDataset):
@@ -293,6 +296,7 @@ class BackgroundRandomCropDataset(Dataset):
             "cls": cls_map_t,
             "offset": off_map_t,
             "centers_Å": torch.empty((0, 3), dtype=torch.float32),
+            "spacing_Å_per_voxel": self.spacing,
         }
 
 class MotorPositiveCropDataset(Dataset):
@@ -373,4 +377,5 @@ class MotorPositiveCropDataset(Dataset):
             "cls": cls_map_t,
             "offset": off_map_t,
             "centers_Å": centers_A,
+            "spacing_Å_per_voxel": self.spacing,
         }

--- a/motor_det/engine/lit_module.py
+++ b/motor_det/engine/lit_module.py
@@ -75,6 +75,9 @@ class LitMotorDet(L.LightningModule):
             prob_thr=0.5, sigma=60.0, iou_thr=0.25
         )[0]
 
+        spacing = batch["spacing_Å_per_voxel"][0]
+        centers_pred = centers_pred * float(spacing)
+
         gt_centers = batch["centers_Å"][0]
         f2, prec, rec, tp, fp, fn = fbeta_score(
             centers_pred, gt_centers, beta=2, dist_thr=1000.0

--- a/motor_det/utils/collate.py
+++ b/motor_det/utils/collate.py
@@ -4,14 +4,18 @@ from torch.utils.data.dataloader import default_collate
 def collate_with_centers(batch):
     """Custom ``collate_fn`` that keeps variable length ``centers_Å`` as a list.
 
-    This function also validates that all tensor fields have consistent shapes
-    across the batch.  If a mismatch is detected a ``ValueError`` is raised with
-    a message describing which key caused the issue.  This helps catch dataset
-    errors where crops of different sizes are accidentally yielded.
+    ``spacing_Å_per_voxel`` is collated normally as a tensor. This function
+    also validates that all tensor fields have consistent shapes across the
+    batch.  If a mismatch is detected a ``ValueError`` is raised with a message
+    describing which key caused the issue.  This helps catch dataset errors
+    where crops of different sizes are accidentally yielded.
     """
 
     centers = [b["centers_Å"] for b in batch]
-    batch_no_centers = [{k: v for k, v in b.items() if k != "centers_Å"} for b in batch]
+    batch_no_centers = [
+        {k: v for k, v in b.items() if k != "centers_Å"}
+        for b in batch
+    ]
 
     # Validate that tensor shapes are consistent across the batch before calling
     # ``default_collate`` which would otherwise fail with a less informative
@@ -19,7 +23,7 @@ def collate_with_centers(batch):
     if len(batch_no_centers) > 1:
         keys = batch_no_centers[0].keys()
         for k in keys:
-            shapes = [b[k].shape for b in batch_no_centers]
+            shapes = [getattr(b[k], "shape", tuple()) for b in batch_no_centers]
             if not all(s == shapes[0] for s in shapes):
                 raise ValueError(
                     f"Inconsistent shapes for key '{k}' when collating batch: {shapes}"


### PR DESCRIPTION
## Summary
- add `spacing_Å_per_voxel` to dataset outputs
- collate scalar spacing in `collate_with_centers`
- scale predictions by spacing before validation metric

## Testing
- `python -m py_compile motor_det/data/dataset.py motor_det/utils/collate.py motor_det/engine/lit_module.py`