### PR TITLE
Implement default test voxel spacing

### DIFF
--- a/motor_det/data/module.py
+++ b/motor_det/data/module.py
@@ -8,7 +8,11 @@ from motor_det.data.dataset import (
     PositiveOnlyCropDataset,
 )
 from motor_det.utils.collate import collate_with_centers
-from motor_det.utils.voxel import voxel_spacing_map, read_train_centers
+from motor_det.utils.voxel import (
+    voxel_spacing_map,
+    read_train_centers,
+    DEFAULT_TEST_SPACING,
+)
 from sklearn.model_selection import StratifiedGroupKFold
 
 
@@ -94,7 +98,7 @@ class MotorDataModule(L.LightningDataModule):
             sub_df = sub_df[sub_df["Motor axis 0"] >= 0]
 
             centers = sub_df[["Motor axis 2", "Motor axis 1", "Motor axis 0"]].values.astype(np.float32)
-            vx = spacing_map.get(tid, 15.0)
+            vx = spacing_map.get(tid, DEFAULT_TEST_SPACING)
 
             if self.positive_only and len(centers) == 0:
                 # skip tomograms without GT when using positive-only crops

--- a/motor_det/engine/infer.py
+++ b/motor_det/engine/infer.py
@@ -13,7 +13,11 @@ from tqdm import tqdm
 from motor_det.data.sliding_window import SlidingWindowDataset
 from motor_det.model.net import MotorDetNet
 from motor_det.postprocess.decoder import decode_with_nms
-from motor_det.utils.voxel import voxel_spacing_map, read_test_ids
+from motor_det.utils.voxel import (
+    voxel_spacing_map,
+    read_test_ids,
+    DEFAULT_TEST_SPACING,
+)
 
 
 class HannWindow:
@@ -198,7 +202,11 @@ if __name__ == "__main__":
     parser.add_argument("--prob_thr", type=float, default=0.50)
     parser.add_argument("--sigma", type=float, default=60.0)
     parser.add_argument("--iou_thr", type=float, default=0.25)
-    parser.add_argument("--default_spacing", type=float, default=15.0)
+    parser.add_argument(
+        "--default_spacing",
+        type=float,
+        default=DEFAULT_TEST_SPACING,
+    )
     parser.add_argument("--early_exit", type=float, default=None)
     args = parser.parse_args()
     main(args)

--- a/motor_det/utils/voxel.py
+++ b/motor_det/utils/voxel.py
@@ -19,8 +19,11 @@ DEFAULT_TEST_SPACING = 15.0
 @lru_cache(maxsize=1)
 def voxel_spacing_map(root: str | Path) -> Dict[str, float]:
     """
-    Returns dict[tomo_id -> voxel_spacing(Å)] for BYU train set.
-    Test tomograms( spacing 미공개 )는 기본값 15 Å 로 채움.
+    Returns ``dict[tomo_id -> voxel_spacing(Å)]`` for BYU train set.
+
+    Test tomograms have no official spacing information.  Those IDs are
+    filled with :data:`DEFAULT_TEST_SPACING` when present in the processed
+    test directory.
     """
     root = Path(root)
     csv_path = root / "raw" / "train_labels.csv"
@@ -31,7 +34,13 @@ def voxel_spacing_map(root: str | Path) -> Dict[str, float]:
     if "Voxel spacing" not in df.columns:
         raise ValueError("'Voxel spacing' column not found in train_labels.csv")
 
-    return dict(zip(df["tomo_id"].astype(str), df["Voxel spacing"].astype(float)))
+    spacing = dict(zip(df["tomo_id"].astype(str), df["Voxel spacing"].astype(float)))
+
+    # Add test IDs with default spacing if available
+    for tid in read_test_ids(root):
+        spacing.setdefault(tid, DEFAULT_TEST_SPACING)
+
+    return spacing
 
 
 # ----------------------------- train centres ---------------------------------


### PR DESCRIPTION
## Summary
- include DEFAULT_TEST_SPACING and populate test IDs in `voxel_spacing_map`
- reuse DEFAULT_TEST_SPACING in data module and inference CLI

## Testing
- `python -m compileall -q motor_det`