### PR TITLE
Fix F2 units and speed up validation

### DIFF
--- a/motor_det/tests/test_quick_train.py
+++ b/motor_det/tests/test_quick_train.py
@@ -22,6 +22,8 @@ dm = MotorDataModule(
     batch_size=1,
     num_workers=12,
     persistent_workers=True,
+    valid_use_gpu_augment=False,
+    pin_memory=True,
 )
 dm.setup()
 

--- a/quick_train_val.py
+++ b/quick_train_val.py
@@ -23,6 +23,8 @@ dm = MotorDataModule(
     batch_size=1,
     num_workers=12,
     persistent_workers=True,
+    valid_use_gpu_augment=False,
+    pin_memory=True,
 )
 dm.setup()
 


### PR DESCRIPTION
## Summary
- document per-dataloader GPU augmentation flag
- allow setting `valid_use_gpu_augment` in `MotorDataModule`
- disable GPU augmentation for validation in quick training script and test

## Testing
- `python motor_det/tests/test_quick_train.py` *(fails: ModuleNotFoundError: No module named 'lightning')*