### PR TITLE
Add configurable NMS algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@ Run the training script:
 
 ```bash
 python -m motor_det.engine.train --data_root data --batch_size 2 --epochs 10 \
-    --lr 3e-4 [--positive_only]
+    --lr 3e-4 [--positive_only] [--nms_algorithm vectorized]
 ```
+
+``nms_algorithm`` controls the NMS method used during validation. The
+default ``vectorized`` algorithm automatically falls back to ``greedy`` when
+more than 1,000 proposals are generated.
 
 Enabling `--pin_memory` is useful when using CPU-based augmentation. When
 CUDA augmentation is active (the default), set `--cpu_augment` before enabling

--- a/motor_det/engine/lit_module.py
+++ b/motor_det/engine/lit_module.py
@@ -23,6 +23,8 @@ class LitMotorDet(L.LightningModule):
         weight_decay: float = 1e-4,
         warmup_steps: int = 500,
         total_steps: int = 30_000,
+        nms_algorithm: str = "vectorized",
+        nms_switch_thr: int = 1000,
     ):
         super().__init__()
         self.save_hyperparameters()
@@ -71,8 +73,14 @@ class LitMotorDet(L.LightningModule):
         offsets = preds["offset"]
 
         centers_pred = decode_with_nms(
-            logits, offsets, stride=4,
-            prob_thr=0.5, sigma=60.0, iou_thr=0.25
+            logits,
+            offsets,
+            stride=4,
+            prob_thr=0.5,
+            sigma=60.0,
+            iou_thr=0.25,
+            algorithm=self.hparams.nms_algorithm,
+            switch_thr=self.hparams.nms_switch_thr,
         )[0]
 
         spacing = batch["spacing_Å_per_voxel"][0]

--- a/motor_det/engine/train.py
+++ b/motor_det/engine/train.py
@@ -39,6 +39,19 @@ def parse_args():
     p.add_argument("--pin_memory", action="store_true", help="Enable DataLoader pin_memory")
     p.add_argument("--prefetch_factor", type=int, default=None)
     p.add_argument("--cpu_augment", action="store_true", help="Run augmentation on CPU")
+    p.add_argument(
+        "--nms_algorithm",
+        type=str,
+        choices=["vectorized", "greedy"],
+        default="vectorized",
+        help="NMS algorithm to use during validation",
+    )
+    p.add_argument(
+        "--nms_switch_thr",
+        type=int,
+        default=1000,
+        help="Switch to greedy NMS when detections exceed this number",
+    )
     return p.parse_args()
 
 
@@ -73,6 +86,8 @@ def main():
         lr=args.lr,
         weight_decay=args.weight_decay,
         total_steps=len(dm.train_dataloader()) * args.epochs,
+        nms_algorithm=args.nms_algorithm,
+        nms_switch_thr=args.nms_switch_thr,
     )
 
     if args.transfer_weights:

--- a/quick_train_val.py
+++ b/quick_train_val.py
@@ -51,6 +51,8 @@ trainer = Trainer(
 )
 
 start = time.time()
-trainer.fit(LitMotorDet(), dm)
+# Vectorized NMS is used by default and automatically switches to greedy
+# when more than 1,000 proposals are present.
+trainer.fit(LitMotorDet(nms_algorithm="vectorized"), dm)
 print(f"\u2714\ufe0e 전체 학습+검증 완료  in {time.time() - start:.1f}s")
 print("Best checkpoint:", ckpt_cb.best_model_path)


### PR DESCRIPTION
## Summary
- support greedy or vectorized NMS in `decoder.decode_with_nms`
- expose NMS parameters in `LitMotorDet` and training CLI
- show usage in quick training example
- document new `--nms_algorithm` option in README

## Testing
- `pytest -q` *(fails: command not found)*