### PR TITLE
Refactor scripts to use dataclass configs

### DIFF
--- a/motor_det/config.py
+++ b/motor_det/config.py
@@ -1,1 +1,114 @@
-#미구현
+from __future__ import annotations
+
+import ast
+import json
+import os
+from dataclasses import dataclass, fields
+from pathlib import Path
+from typing import Any, Type, TypeVar
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
+
+from motor_det.utils.voxel import DEFAULT_TEST_SPACING
+
+T = TypeVar("T")
+
+
+def _parse_file(path: Path) -> dict[str, Any]:
+    if not path:
+        return {}
+    with open(path, "r") as f:
+        if path.suffix in {".yaml", ".yml"}:
+            if yaml is None:
+                raise ImportError("PyYAML is required for YAML configuration files")
+            data = yaml.safe_load(f) or {}
+        else:
+            data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError("Configuration file must contain a mapping at the top level")
+    return data
+
+
+def _apply_env(data: dict[str, Any], cls: Type[T], prefix: str | None) -> None:
+    if not prefix:
+        return
+    prefix = prefix.upper()
+    for field in fields(cls):
+        env_key = f"{prefix}{field.name.upper()}"
+        if env_key in os.environ:
+            val = os.environ[env_key]
+            try:
+                data[field.name] = ast.literal_eval(val)
+            except Exception:
+                data[field.name] = val
+
+
+def _load(cls: Type[T], path: str | Path | None, env_prefix: str | None) -> T:
+    data: dict[str, Any] = {}
+    if path is not None:
+        data.update(_parse_file(Path(path)))
+    _apply_env(data, cls, env_prefix)
+    return cls(**data)
+
+
+@dataclass
+class TrainingConfig:
+    """Configuration for model training."""
+
+    data_root: str
+    fold: int = 0
+    batch_size: int = 2
+    num_workers: int = 4
+    persistent_workers: bool = False
+    positive_only: bool = False
+    train_crop_size: tuple[int, int, int] = (96, 128, 128)
+    valid_crop_size: tuple[int, int, int] = (192, 128, 128)
+    pin_memory: bool = False
+    prefetch_factor: int | None = None
+    use_gpu_augment: bool = True
+    valid_use_gpu_augment: bool | None = None
+    epochs: int = 10
+    lr: float = 3e-4
+    weight_decay: float = 1e-4
+    transfer_weights: str | None = None
+    freeze_backbone_epochs: int = 0
+    gpus: int = 1
+    nms_algorithm: str = "vectorized"
+    nms_switch_thr: int = 1000
+
+    @classmethod
+    def load(cls, path: str | Path | None = None, *, env_prefix: str | None = "BYU_TRAIN_") -> "TrainingConfig":
+        return _load(cls, path, env_prefix)
+
+
+@dataclass
+class InferenceConfig:
+    """Configuration for inference."""
+
+    weights: str
+    data_root: str
+    out_csv: str
+    win_d: int = 192
+    win_h: int = 128
+    win_w: int = 128
+    stride_d: int = 96
+    stride_h: int = 64
+    stride_w: int = 64
+    stride_head: int = 2
+    batch: int = 1
+    num_workers: int = 4
+    prob_thr: float = 0.50
+    sigma: float = 60.0
+    iou_thr: float = 0.25
+    default_spacing: float = DEFAULT_TEST_SPACING
+    early_exit: float | None = None
+
+    @classmethod
+    def load(cls, path: str | Path | None = None, *, env_prefix: str | None = "BYU_INFER_") -> "InferenceConfig":
+        return _load(cls, path, env_prefix)
+
+
+__all__ = ["TrainingConfig", "InferenceConfig"]

--- a/motor_det/engine/infer.py
+++ b/motor_det/engine/infer.py
@@ -18,6 +18,7 @@ from motor_det.utils.voxel import (
     read_test_ids,
     DEFAULT_TEST_SPACING,
 )
+from motor_det.config import InferenceConfig
 
 
 class HannWindow:
@@ -142,7 +143,7 @@ def infer_single_tomo(
     return ctr_A_xyz[None, :]                          # (1,3)
 
 
-def main(cfg):
+def infer(cfg: InferenceConfig):
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     torch.set_float32_matmul_precision("high")
 
@@ -187,28 +188,15 @@ def main(cfg):
     print("Saved →", cfg.out_csv)
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--weights", required=True)
-    parser.add_argument("--data_root", required=True)
-    parser.add_argument("--out_csv",  required=True)
-    parser.add_argument("--win_d", type=int, default=192)
-    parser.add_argument("--win_h", type=int, default=128)
-    parser.add_argument("--win_w", type=int, default=128)
-    parser.add_argument("--stride_d", type=int, default=96)
-    parser.add_argument("--stride_h", type=int, default=64)
-    parser.add_argument("--stride_w", type=int, default=64)
-    parser.add_argument("--stride_head", type=int, default=2)
-    parser.add_argument("--batch", type=int, default=1)
-    parser.add_argument("--num_workers", type=int, default=4)
-    parser.add_argument("--prob_thr", type=float, default=0.50)
-    parser.add_argument("--sigma", type=float, default=60.0)
-    parser.add_argument("--iou_thr", type=float, default=0.25)
-    parser.add_argument(
-        "--default_spacing",
-        type=float,
-        default=DEFAULT_TEST_SPACING,
-    )
-    parser.add_argument("--early_exit", type=float, default=None)
+def main() -> None:
+    parser = argparse.ArgumentParser(description="BYU Motor inference")
+    parser.add_argument("--config", help="YAML/JSON configuration file")
+    parser.add_argument("--env_prefix", default="BYU_INFER_", help="Env var prefix")
     args = parser.parse_args()
-    main(args)
+
+    cfg = InferenceConfig.load(args.config, env_prefix=args.env_prefix)
+    infer(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/motor_det/engine/train.py
+++ b/motor_det/engine/train.py
@@ -9,6 +9,7 @@ Example:
         --lr 3e-4
 """
 from __future__ import annotations
+
 import argparse
 from pathlib import Path
 
@@ -18,99 +19,76 @@ import torch
 from motor_det.data.module import MotorDataModule
 from motor_det.engine.lit_module import LitMotorDet
 from motor_det.callbacks.freeze_backbone import FreezeBackbone
+from motor_det.config import TrainingConfig
 
 
 def parse_args():
-    p = argparse.ArgumentParser()
-    p.add_argument("--data_root", type=str, required=True)
-    p.add_argument("--batch_size", type=int, default=2)
-    p.add_argument("--epochs", type=int, default=10)
-    p.add_argument("--lr", type=float, default=3e-4)
-    p.add_argument("--weight_decay", type=float, default=1e-4)
-    p.add_argument("--fold", type=int, default=0)
-    p.add_argument("--positive_only", action="store_true")
-    p.add_argument("--gpus", type=int, default=1)
-    p.add_argument("--train_depth_window_size", type=int, default=96)
-    p.add_argument("--train_spatial_window_size", type=int, default=128)
-    p.add_argument("--valid_depth_window_size", type=int, default=192)
-    p.add_argument("--valid_spatial_window_size", type=int, default=128)
-    p.add_argument("--transfer_weights", type=str, default=None)
-    p.add_argument("--freeze_backbone_epochs", type=int, default=0)
-    p.add_argument("--pin_memory", action="store_true", help="Enable DataLoader pin_memory")
-    p.add_argument("--prefetch_factor", type=int, default=None)
-    p.add_argument("--cpu_augment", action="store_true", help="Run augmentation on CPU")
+    p = argparse.ArgumentParser(description="BYU Motor training")
+    p.add_argument("--config", type=str, help="YAML/JSON configuration file")
     p.add_argument(
-        "--nms_algorithm",
+        "--env_prefix",
         type=str,
-        choices=["vectorized", "greedy"],
-        default="vectorized",
-        help="NMS algorithm to use during validation",
-    )
-    p.add_argument(
-        "--nms_switch_thr",
-        type=int,
-        default=1000,
-        help="Switch to greedy NMS when detections exceed this number",
+        default="BYU_TRAIN_",
+        help="Prefix for environment variable overrides",
     )
     return p.parse_args()
 
 
-def main():
-    args = parse_args()
+def train(cfg: TrainingConfig):
 
     # -------- Data --------
     dm = MotorDataModule(
-        data_root=args.data_root,
-        fold=args.fold,
-        batch_size=args.batch_size,
-        num_workers=4,
-        positive_only=args.positive_only,
-        pin_memory=args.pin_memory,
-        prefetch_factor=args.prefetch_factor,
-        use_gpu_augment=not args.cpu_augment,
-        train_crop_size=(
-            args.train_depth_window_size,
-            args.train_spatial_window_size,
-            args.train_spatial_window_size,
-        ),
-        valid_crop_size=(
-            args.valid_depth_window_size,
-            args.valid_spatial_window_size,
-            args.valid_spatial_window_size,
-        ),
+        data_root=cfg.data_root,
+        fold=cfg.fold,
+        batch_size=cfg.batch_size,
+        num_workers=cfg.num_workers,
+        persistent_workers=cfg.persistent_workers,
+        positive_only=cfg.positive_only,
+        train_crop_size=cfg.train_crop_size,
+        valid_crop_size=cfg.valid_crop_size,
+        pin_memory=cfg.pin_memory,
+        prefetch_factor=cfg.prefetch_factor,
+        use_gpu_augment=cfg.use_gpu_augment,
+        valid_use_gpu_augment=cfg.valid_use_gpu_augment,
     )
     dm.setup()
 
     # -------- Model --------
     model = LitMotorDet(
-        lr=args.lr,
-        weight_decay=args.weight_decay,
-        total_steps=len(dm.train_dataloader()) * args.epochs,
-        nms_algorithm=args.nms_algorithm,
-        nms_switch_thr=args.nms_switch_thr,
+        lr=cfg.lr,
+        weight_decay=cfg.weight_decay,
+        total_steps=len(dm.train_dataloader()) * cfg.epochs,
+        nms_algorithm=cfg.nms_algorithm,
+        nms_switch_thr=cfg.nms_switch_thr,
     )
 
-    if args.transfer_weights:
-        ckpt = torch.load(args.transfer_weights, map_location="cpu")
+    if cfg.transfer_weights:
+        ckpt = torch.load(cfg.transfer_weights, map_location="cpu")
         state_dict = ckpt.get("state_dict", ckpt)
         model.load_state_dict(state_dict, strict=False)
 
     # -------- Trainer --------
     callbacks = []
-    if args.freeze_backbone_epochs > 0:
-        callbacks.append(FreezeBackbone(args.freeze_backbone_epochs))
+    if cfg.freeze_backbone_epochs > 0:
+        callbacks.append(FreezeBackbone(cfg.freeze_backbone_epochs))
 
     trainer = L.Trainer(
-        max_epochs=args.epochs,
-        accelerator="gpu" if args.gpus else "cpu",
-        devices=args.gpus if args.gpus else 1,
+        max_epochs=cfg.epochs,
+        accelerator="gpu" if cfg.gpus else "cpu",
+        devices=cfg.gpus if cfg.gpus else 1,
         precision="16-mixed",          # 사용할 AMP 정밀도
         log_every_n_steps=50,
-        default_root_dir=Path("runs") / f"motor_fold{args.fold}",
+        default_root_dir=Path("runs") / f"motor_fold{cfg.fold}",
         callbacks=callbacks,
     )
 
     trainer.fit(model, datamodule=dm)
+
+
+def main() -> None:
+    args = parse_args()
+    cfg = TrainingConfig.load(args.config, env_prefix=args.env_prefix)
+    train(cfg)
 
 
 if __name__ == "__main__":

--- a/quick_train_val.py
+++ b/quick_train_val.py
@@ -1,14 +1,10 @@
 import os
 import time
-from pathlib import Path
 import lightning as L
 import torch
-from lightning.pytorch.callbacks import ModelCheckpoint, RichProgressBar
-from lightning.pytorch.loggers import CSVLogger
-from lightning.pytorch import Trainer
 
-from motor_det.data.module import MotorDataModule
-from motor_det.engine.lit_module import LitMotorDet
+from motor_det.engine.train import train
+from motor_det.config import TrainingConfig
 
 DATA_ROOT = r"D:\project\Kaggle\BYU\byu-motor\data"
 RUNS_DIR = "runs/quick_val"
@@ -17,7 +13,7 @@ os.makedirs(RUNS_DIR, exist_ok=True)
 L.seed_everything(42)
 torch.set_float32_matmul_precision("high")
 
-dm = MotorDataModule(
+cfg = TrainingConfig(
     data_root=DATA_ROOT,
     fold=0,
     batch_size=1,
@@ -25,34 +21,9 @@ dm = MotorDataModule(
     persistent_workers=True,
     valid_use_gpu_augment=False,
     pin_memory=True,
-)
-dm.setup()
-
-ckpt_cb = ModelCheckpoint(
-    dirpath=RUNS_DIR,
-    filename="best",
-    monitor="val/f2",
-    mode="max",
-    save_top_k=1,
-)
-
-csv_logger = CSVLogger(RUNS_DIR, name="tensorboard")
-
-trainer = Trainer(
-    accelerator="gpu",
-    devices=1,
-    precision="16-mixed",
-    max_epochs=10,
-    val_check_interval=20,
-    limit_val_batches=0.1,
-    log_every_n_steps=20,
-    callbacks=[RichProgressBar(refresh_rate=20), ckpt_cb],
-    logger=csv_logger,
+    epochs=10,
 )
 
 start = time.time()
-
-trainer.fit(LitMotorDet(nms_algorithm="vectorized", nms_switch_thr=1000), dm)
-
+train(cfg)
 print(f"\u2714\ufe0e 전체 학습+검증 완료  in {time.time() - start:.1f}s")
-print("Best checkpoint:", ckpt_cb.best_model_path)


### PR DESCRIPTION
## Summary
- add dataclass based TrainingConfig and InferenceConfig with loader helpers
- use config objects in engine.train and engine.infer
- simplify quick training script to use TrainingConfig

## Testing
- `python -m py_compile motor_det/config.py motor_det/engine/train.py motor_det/engine/infer.py quick_train_val.py`
- `pytest -q motor_det/tests/test_quick_train.py` *(fails: `pytest: command not found`)*