### PR TITLE
Improve package init exports

### DIFF
--- a/motor_det/__init__.py
+++ b/motor_det/__init__.py
@@ -1,1 +1,14 @@
-#BYU
+"""Top-level package for BYU Motor Detection.
+
+This module exposes the training data module and Lightning module used in
+the BYU motor detection pipeline.
+"""
+
+from importlib.metadata import version as _version
+
+from .data.module import MotorDataModule
+from .engine.lit_module import LitMotorDet
+
+__all__ = ["MotorDataModule", "LitMotorDet"]
+
+__version__ = _version("motor_det")


### PR DESCRIPTION
## Summary
- expose data and Lightning modules at package level
- set `__version__` from package metadata
- add module documentation and `__all__`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*