### PR TITLE
Expose validation check interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ Run a short training cycle to gauge model quality:
 ```bash
 python -m motor_det.engine.train \
   --data_root D:\\project\\Kaggle\\BYU\\byu-motor\\data \
-  --batch_size 1 --max_steps 1500 --limit_val_batches 0.1
+  --batch_size 1 \
+  --max_steps 1500 \
+  --limit_val_batches 0.1 \
+  --val_check_interval 1500
 ```
 
 This trains for roughly 1500 iterations and evaluates on 10% of the validation

--- a/motor_det/config.py
+++ b/motor_det/config.py
@@ -83,6 +83,7 @@ class TrainingConfig:
     nms_switch_thr: int = 1000
     max_steps: int | None = None
     limit_val_batches: float | int = 1.0
+    val_check_interval: float | int = 1.0
 
     @classmethod
     def load(cls, path: str | Path | None = None, *, env_prefix: str | None = "BYU_TRAIN_") -> "TrainingConfig":

--- a/motor_det/engine/train.py
+++ b/motor_det/engine/train.py
@@ -47,6 +47,12 @@ def parse_args():
     p.add_argument("--max_steps", type=int, default=None, help="Maximum training steps")
     p.add_argument("--limit_val_batches", type=float, default=1.0, help="Fraction of validation batches to run")
     p.add_argument(
+        "--val_check_interval",
+        type=float,
+        default=1.0,
+        help="Interval (in steps or fraction of an epoch) between validation runs",
+    )
+    p.add_argument(
         "--env_prefix",
         type=str,
         default="BYU_TRAIN_",
@@ -104,6 +110,7 @@ def train(cfg: TrainingConfig):
         precision="16-mixed",          # 사용할 AMP 정밀도
         log_every_n_steps=50,
         default_root_dir=Path("runs") / f"motor_fold{cfg.fold}",
+        val_check_interval=cfg.val_check_interval,
         limit_val_batches=cfg.limit_val_batches,
         callbacks=callbacks,
     )
@@ -145,6 +152,7 @@ def main() -> None:
     cfg.cutmix_prob = args.cutmix
     cfg.max_steps = args.max_steps
     cfg.limit_val_batches = args.limit_val_batches
+    cfg.val_check_interval = args.val_check_interval
 
     train(cfg)
 

--- a/quick_train_val.py
+++ b/quick_train_val.py
@@ -23,6 +23,7 @@ cfg = TrainingConfig(
     pin_memory=True,
     epochs=10,
     max_steps=1500,
+    val_check_interval=1500,
     limit_val_batches=0.1,
 )
 


### PR DESCRIPTION
## Summary
- allow configuring Lightning's `val_check_interval`
- propagate the new option through the training script and default config
- set `val_check_interval=1500` for the quick training utility
- document the new CLI flag in the README

## Testing
- `git log -1 --stat`