### PR TITLE
Fix val metrics and add dataloader tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,18 @@ python -m motor_det.engine.infer \
     --out_csv preds.csv
 ```
 
+## 문제 해결
+
+### 느린 DataLoader 초기화
+
+Windows 환경에서 많은 `num_workers`를 사용할 경우 첫 스텝 시작 전이나
+검증 단계 직전에 대기 시간이 길어질 수 있습니다.
+아래와 같이 작업자 수를 줄이고 `--no-persistent_workers` 옵션을 지정하면
+속도가 개선되는 경우가 있습니다.
+
+```bash
+python -m motor_det.engine.train \
+  --data_root <DATA_ROOT> \
+  --num_workers 0 --no-persistent_workers
+```
+

--- a/motor_det/engine/lit_module.py
+++ b/motor_det/engine/lit_module.py
@@ -137,7 +137,9 @@ class LitMotorDet(L.LightningModule):
                 "val/fp":   fp,
                 "val/fn":   fn,
             },
-            prog_bar=True
+            prog_bar=True,
+            on_step=False,
+            on_epoch=True,
         )
 
         # → Lightning 2.x 에서는 반환값이 필요 없으므로 그냥 종료


### PR DESCRIPTION
## Summary
- ensure validation metrics are logged at epoch end
- document how to reduce startup delay on Windows

## Testing
- `git status --short`