### PR TITLE
Print metrics every training and validation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ python -m motor_det.engine.train \
 ```bash
 tensorboard --logdir runs
 ```
+TensorBoard를 사용할 수 없는 환경이라면 이벤트 파일을 직접 읽어 지표를 확인할 수 있습니다. 다음 스크립트가 `val/f2`, `val/tp` 등 주요 값을 스텝별로 출력합니다:
+
+```bash
+python -m motor_det.utils.event_reader runs/motor_fold0
+```
+
+학습 중에도 손실과 정밀도 같은 지표가 매 스텝마다 터미널에 출력되므로,
+TensorBoard 없이도 진행 상황을 바로 확인할 수 있습니다.
+
 
 ## 추론
 

--- a/motor_det/utils/event_reader.py
+++ b/motor_det/utils/event_reader.py
@@ -1,0 +1,74 @@
+"""Simple TensorBoard event file reader.
+
+This module provides a helper function to print scalar metrics
+logged during training or validation.  It uses TensorBoard's
+``EventAccumulator`` to read ``events.out.tfevents.*`` files and
+extract the values for the given tags.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
+
+__all__ = ["read_scalars", "print_scalars"]
+
+
+def _find_event_file(logdir: str | Path) -> Path:
+    logdir = Path(logdir)
+    if logdir.is_file():
+        return logdir
+    events = sorted(logdir.glob("events.out.tfevents.*"))
+    if not events:
+        raise FileNotFoundError(f"no event file found in {logdir}")
+    return events[-1]
+
+
+def read_scalars(logdir: str | Path, tags: Iterable[str]) -> dict[str, list[tuple[int, float]]]:
+    """Return scalar values for the specified tags.
+
+    Parameters
+    ----------
+    logdir : str or Path
+        Path to a directory containing an event file or the event file itself.
+    tags : iterable of str
+        Scalar tags to read.
+    """
+    event_file = _find_event_file(logdir)
+    acc = EventAccumulator(str(event_file))
+    acc.Reload()
+
+    result: dict[str, list[tuple[int, float]]] = {}
+    for tag in tags:
+        result[tag] = [(e.step, e.value) for e in acc.Scalars(tag)]
+    return result
+
+
+def print_scalars(logdir: str | Path, tags: Iterable[str] | None = None) -> None:
+    """Print scalar metrics stored in an event file.
+
+    If *tags* is ``None``, ``{"val/f2", "val/tp", "val/fp", "val/fn"}`` is used.
+    """
+    if tags is None:
+        tags = ["val/f2", "val/tp", "val/fp", "val/fn"]
+
+    scalars = read_scalars(logdir, tags)
+    header = "step\t" + "\t".join(tags)
+    print(header)
+    steps = [s[0] for s in scalars[next(iter(tags))]] if scalars else []
+    for i, step in enumerate(steps):
+        values = [f"{scalars[tag][i][1]:.6g}" for tag in tags]
+        print(step, *values, sep="\t")
+
+
+if __name__ == "__main__":  # pragma: no cover - simple CLI
+    import argparse
+
+    p = argparse.ArgumentParser(description="Print scalars from a TensorBoard event file")
+    p.add_argument("logdir", type=str, help="Event file or directory containing it")
+    p.add_argument("--tags", nargs="*", default=None, help="Scalar tags to display")
+    args = p.parse_args()
+
+    print_scalars(args.logdir, args.tags)


### PR DESCRIPTION
## Summary
- print metrics to console each train/val step for easier monitoring
- document console metrics in README

## Testing
- `python -m py_compile motor_det/engine/lit_module.py`
- `python -m compileall -q motor_det`
