### PR TITLE
Fix stride mismatch and adjust logging

### DIFF
--- a/motor_det/config.py
+++ b/motor_det/config.py
@@ -80,7 +80,7 @@ class TrainingConfig:
     freeze_backbone_epochs: int = 0
     gpus: int = 1
     nms_algorithm: str = "vectorized"
-    nms_switch_thr: int = 1000
+    nms_switch_thr: int = 1500
     max_steps: int | None = None
     limit_val_batches: float | int = 1.0
     val_check_interval: float | int = 1.0
@@ -108,7 +108,7 @@ class InferenceConfig:
     batch: int = 1
     num_workers: int = 4
 
-    prob_thr: float = 0.5
+    prob_thr: float = 0.6
     sigma: float = 60.0
     iou_thr: float = 0.25
     default_spacing: float = DEFAULT_TEST_SPACING

--- a/motor_det/engine/lit_module.py
+++ b/motor_det/engine/lit_module.py
@@ -26,7 +26,7 @@ class LitMotorDet(L.LightningModule):
         warmup_steps: int = 500,
         total_steps: int = 30_000,
         nms_algorithm: str = "vectorized",
-        nms_switch_thr: int = 1000,
+        nms_switch_thr: int = 1500,
     ):
         super().__init__()
         self.save_hyperparameters()
@@ -63,12 +63,7 @@ class LitMotorDet(L.LightningModule):
         self.log_dict(logs, prog_bar=True, on_step=True, on_epoch=True,
                       batch_size=batch_size)
 
-        # Print metrics to the console for real-time monitoring
-        msg = (
-            f"[{stage.upper()}] step {self.global_step:>6}: "
-            + ", ".join(f"{k.split('/')[-1]}={float(v):.4f}" for k, v in logs.items())
-        )
-        rank_zero_info(msg)
+        # Skip per-step console logging to keep output concise
 
         return loss
 
@@ -90,8 +85,8 @@ class LitMotorDet(L.LightningModule):
         centers_pred = decode_with_nms(
             logits,
             offsets,
-            stride=4,
-            prob_thr=0.5,
+            stride=2,
+            prob_thr=0.6,
             sigma=60.0,
             iou_thr=0.25,
             algorithm=self.hparams.nms_algorithm,
@@ -119,10 +114,7 @@ class LitMotorDet(L.LightningModule):
         # 복잡하게 만들 수 있으므로 더 이상 기록하지 않는다.
         # 필요한 경우 이벤트 파일에서 직접 값을 확인한다.
 
-        # Print step metrics to the console
-        rank_zero_info(
-            f"[VAL] step {self.global_step:>6}: f2={f2:.4f}, tp={tp}, fp={fp}, fn={fn}"
-        )
+        # Skip per-step validation logging
 
         return {"tp": tp_t, "fp": fp_t, "fn": fn_t}
 

--- a/motor_det/postprocess/decoder.py
+++ b/motor_det/postprocess/decoder.py
@@ -38,7 +38,7 @@ def decode_detections(
     logits: torch.Tensor,         # (B,1,D,H,W)
     offsets: torch.Tensor,        # (B,3,D,H,W)
     stride: int = 2,
-    prob_thr: float = 0.5,
+    prob_thr: float = 0.6,
 ) -> List[torch.Tensor]:
     """
     배치-별 예측 좌표(Å) 리스트 반환
@@ -97,11 +97,11 @@ def decode_with_nms(
     logits: torch.Tensor,
     offsets: torch.Tensor,
     stride: int = 2,
-    prob_thr: float = 0.5,
+    prob_thr: float = 0.6,
     sigma: float = 60.0,
     iou_thr: float = 0.25,
     algorithm: str = "vectorized",
-    switch_thr: int = 1000,
+    switch_thr: int = 1500,
 ) -> List[torch.Tensor]:
     """Heatmap+Offset → NMS 후 Å 좌표 리스트.
 

--- a/motor_det/tests/measure_performance.py
+++ b/motor_det/tests/measure_performance.py
@@ -37,8 +37,8 @@ def evaluate(weights: Path, data_root: Path, fold: int = 0) -> dict[str, float]:
             centers = decode_with_nms(
                 out["cls"],
                 out["offset"],
-                stride=4,
-                prob_thr=0.5,
+                stride=2,
+                prob_thr=0.6,
                 sigma=60.0,
                 iou_thr=0.25,
             )[0]


### PR DESCRIPTION
## Summary
- align NMS stride with network stride
- raise probability threshold and NMS switching threshold
- remove noisy per-step console logs

## Testing
- `python -m py_compile motor_det/postprocess/decoder.py motor_det/engine/lit_module.py motor_det/config.py motor_det/tests/measure_performance.py`