### PR TITLE
Implement weighted sliding window tiling inference

### DIFF
--- a/motor_det/config.py
+++ b/motor_det/config.py
@@ -110,6 +110,12 @@ class InferenceConfig:
     batch: int = 1
     num_workers: int = 4
 
+    # optional sliding window tiling
+    num_tiles_d: int | None = None
+    num_tiles_h: int | None = None
+    num_tiles_w: int | None = None
+    tile_xy: int | None = None
+
     prob_thr: float = 0.6
     sigma: float = 60.0
     iou_thr: float = 0.25


### PR DESCRIPTION
## Summary
- extend sliding window dataset with custom tile counts
- support optional tiled weighted accumulation during inference
- allow configuring tiling via `InferenceConfig`

## Testing
- `python -m py_compile motor_det/data/sliding_window.py motor_det/engine/infer.py motor_det/config.py`
