### PR TITLE
Add dataset for random positive center crops

### DIFF
--- a/motor_det/data/module.py
+++ b/motor_det/data/module.py
@@ -5,7 +5,7 @@ from torch.utils.data import DataLoader, ConcatDataset
 from pathlib import Path
 from motor_det.data.dataset import (
     MotorTrainDataset,
-    PositiveOnlyCropDataset,
+    MotorRandomPositiveCropDataset,
 )
 from motor_det.utils.collate import collate_with_centers
 from motor_det.utils.voxel import (
@@ -126,7 +126,7 @@ class MotorDataModule(L.LightningDataModule):
                 continue
 
             if self.positive_only:
-                ds = PositiveOnlyCropDataset(
+                ds = MotorRandomPositiveCropDataset(
                     zarr_path,
                     centers,
                     vx,


### PR DESCRIPTION
## Summary
- add `MotorRandomPositiveCropDataset` for random crops centered on positive examples
- use `MotorRandomPositiveCropDataset` when `--positive_only` is set in data module

## Testing
- ❌ `pytest -q` (failed to run: command not found)
- ❌ `python motor_det/tests/test_quick_train.py` (failed to run: ModuleNotFoundError: No module named 'lightning')
