### PR TITLE
Add random positive crop dataset to datamodule

### DIFF
--- a/motor_det/data/module.py
+++ b/motor_det/data/module.py
@@ -5,7 +5,7 @@ from torch.utils.data import DataLoader, ConcatDataset
 from pathlib import Path
 from motor_det.data.dataset import (
     MotorTrainDataset,
-    PositiveOnlyCropDataset,
+    MotorRandomPositiveCropDataset,
 )
 from motor_det.utils.collate import collate_with_centers
 from motor_det.utils.voxel import (
@@ -126,7 +126,7 @@ class MotorDataModule(L.LightningDataModule):
                 continue
 
             if self.positive_only:
-                ds = PositiveOnlyCropDataset(
+                ds = MotorRandomPositiveCropDataset(
                     zarr_path,
                     centers,
                     vx,


### PR DESCRIPTION
## Summary
- import `MotorRandomPositiveCropDataset` in the datamodule
- use it when `--positive_only` is enabled

## Testing
- `pytest -q` *(fails: command not found)*
- `python motor_det/tests/test_quick_train.py` *(fails: ModuleNotFoundError: No module named 'lightning')*