### PR TITLE
Fix cached_property usage to support PyTorch

### DIFF
--- a/motor_det/data/detection/sliding_window_dataset.py
+++ b/motor_det/data/detection/sliding_window_dataset.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 import numpy as np
 import torch
+from functools import cached_property
 import zarr
 from torch.utils.data import Dataset
 
@@ -86,7 +87,7 @@ class SlidingWindowDataset(Dataset, ObjectDetectionMixin):
         self._cache_size = int(cache_size)
         self._patch_cache: OrderedDict[Tuple[int, int, int], np.ndarray] = OrderedDict()
 
-    @torch.cached_property
+    @cached_property
     def tiles(self) -> List[Tuple[slice, slice, slice]]:
         if self.num_tiles is None:
             return compute_tiles(self.store.shape, self.window, self.stride)

--- a/motor_det/engine/infer.py
+++ b/motor_det/engine/infer.py
@@ -8,6 +8,7 @@ from typing import Sequence, Tuple
 
 import numpy as np
 import torch
+from functools import cached_property
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
@@ -24,11 +25,11 @@ class HannWindow:
         self.window = window
         self.stride = stride
 
-    @torch.cached_property
+    @cached_property
     def full(self) -> np.ndarray:
         return cosine_hann_3d(self.window)
 
-    @torch.cached_property
+    @cached_property
     def downsampled(self) -> np.ndarray:
         return self.full[:: self.stride, :: self.stride, :: self.stride]
 


### PR DESCRIPTION
## Summary
- use functools.cached_property instead of torch.cached_property
- update dataset and inference code accordingly

## Testing
- `python -m motor_det.engine.train --help` *(fails: ModuleNotFoundError: No module named 'lightning')*
- `pytest -q` *(fails: command not found)*