### PR TITLE
Fix cached_property usage to support PyTorch

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ python -m motor_det.engine.train \
 
 
 검증 단계에서 사용할 NMS 방식은 `nms_algorithm` 옵션으로 결정하며 기본값인 `vectorized` 모드는 탐지 개수가 `--nms_switch_thr`를 넘으면 자동으로 `greedy`로 전환됩니다.
+`--prob_thr` 값으로 NMS 전에 적용되는 최소 확률을 조절할 수 있으며 초기 학습 단계에서 너무 높은 임계값 때문에 탐지가 전혀 없을 경우 이 값을 낮추면 도움이 됩니다.
 
 `--cpu_augment`를 사용하면 증강을 CPU에서 수행합니다. 이 경우 `--pin_memory`를 함께 지정하면 데이터 전송 속도를 높일 수 있습니다. 본 스크립트는 기본적으로 `persistent_workers=True`와 `prefetch_factor=2`를 사용해 데이터 로더 초기화를 최소화합니다. 필요하면 `--no-persistent_workers` 플래그로 끌 수 있습니다.
 

--- a/motor_det/config.py
+++ b/motor_det/config.py
@@ -81,6 +81,7 @@ class TrainingConfig:
     gpus: int = 1
     nms_algorithm: str = "vectorized"
     nms_switch_thr: int = 1500
+    prob_thr: float = 0.6
     max_steps: int | None = None
     limit_val_batches: float | int = 1.0
     val_check_interval: float | int = 1.0

--- a/motor_det/data/detection/sliding_window_dataset.py
+++ b/motor_det/data/detection/sliding_window_dataset.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 import numpy as np
 import torch
+from functools import cached_property
 import zarr
 from torch.utils.data import Dataset
 
@@ -86,7 +87,7 @@ class SlidingWindowDataset(Dataset, ObjectDetectionMixin):
         self._cache_size = int(cache_size)
         self._patch_cache: OrderedDict[Tuple[int, int, int], np.ndarray] = OrderedDict()
 
-    @torch.cached_property
+    @cached_property
     def tiles(self) -> List[Tuple[slice, slice, slice]]:
         if self.num_tiles is None:
             return compute_tiles(self.store.shape, self.window, self.stride)

--- a/motor_det/engine/infer.py
+++ b/motor_det/engine/infer.py
@@ -8,6 +8,7 @@ from typing import Sequence, Tuple
 
 import numpy as np
 import torch
+from functools import cached_property
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
@@ -24,11 +25,11 @@ class HannWindow:
         self.window = window
         self.stride = stride
 
-    @torch.cached_property
+    @cached_property
     def full(self) -> np.ndarray:
         return cosine_hann_3d(self.window)
 
-    @torch.cached_property
+    @cached_property
     def downsampled(self) -> np.ndarray:
         return self.full[:: self.stride, :: self.stride, :: self.stride]
 

--- a/motor_det/engine/lit_module.py
+++ b/motor_det/engine/lit_module.py
@@ -27,6 +27,7 @@ class LitMotorDet(L.LightningModule):
         total_steps: int = 30_000,
         nms_algorithm: str = "vectorized",
         nms_switch_thr: int = 1500,
+        prob_thr: float = 0.6,
         focal_gamma: float = 2.0,
         pos_weight_clip: float = 5.0,
     ):
@@ -93,7 +94,7 @@ class LitMotorDet(L.LightningModule):
             logits,
             offsets,
             stride=2,
-            prob_thr=0.6,
+            prob_thr=self.hparams.prob_thr,
             sigma=60.0,
             iou_thr=0.25,
             algorithm=self.hparams.nms_algorithm,

--- a/motor_det/engine/train.py
+++ b/motor_det/engine/train.py
@@ -56,6 +56,7 @@ def parse_args():
     p.add_argument("--cpu_augment", action="store_true", help="Run augmentation on CPU")
     p.add_argument("--mixup", type=float, default=0.0, help="MixUp probability")
     p.add_argument("--cutmix", type=float, default=0.0, help="CutMix probability")
+    p.add_argument("--prob_thr", type=float, default=0.6, help="NMS probability threshold")
     p.add_argument("--max_steps", type=int, default=None, help="Maximum training steps")
     p.add_argument("--limit_val_batches", type=float, default=1.0, help="Fraction of validation batches to run")
     p.add_argument(
@@ -110,6 +111,7 @@ def train(cfg: TrainingConfig):
         total_steps=total_steps,
         nms_algorithm=cfg.nms_algorithm,
         nms_switch_thr=cfg.nms_switch_thr,
+        prob_thr=cfg.prob_thr,
         focal_gamma=cfg.focal_gamma,
         pos_weight_clip=cfg.pos_weight_clip,
     )
@@ -177,6 +179,7 @@ def main() -> None:
     cfg.use_gpu_augment = not args.cpu_augment
     cfg.mixup_prob = args.mixup
     cfg.cutmix_prob = args.cutmix
+    cfg.prob_thr = args.prob_thr
     cfg.max_steps = args.max_steps
     cfg.limit_val_batches = args.limit_val_batches
     cfg.val_check_interval = args.val_check_interval


### PR DESCRIPTION
## Summary
- make validation NMS probability threshold configurable via `--prob_thr`
- document new option in README

## Testing
- `python -m motor_det.engine.train --help` *(fails: ModuleNotFoundError: No module named 'lightning')*
- `pytest -q` *(fails: command not found)*