### PR TITLE
Lower default prob_thr

### DIFF
--- a/motor_det/config.py
+++ b/motor_det/config.py
@@ -81,7 +81,7 @@ class TrainingConfig:
     gpus: int = 1
     nms_algorithm: str = "vectorized"
     nms_switch_thr: int = 1500
-    prob_thr: float = 0.6
+    prob_thr: float = 0.1
     max_steps: int | None = None
     limit_val_batches: float | int = 1.0
     val_check_interval: float | int = 1.0

--- a/motor_det/engine/lit_module.py
+++ b/motor_det/engine/lit_module.py
@@ -27,7 +27,7 @@ class LitMotorDet(L.LightningModule):
         total_steps: int = 30_000,
         nms_algorithm: str = "vectorized",
         nms_switch_thr: int = 1500,
-        prob_thr: float = 0.6,
+        prob_thr: float = 0.1,
         focal_gamma: float = 2.0,
         pos_weight_clip: float = 5.0,
     ):


### PR DESCRIPTION
## Summary
- lower `prob_thr` default in `LitMotorDet` and training config

## Testing
- `pytest -q` *(fails: command not found)*