### PR TITLE
Add prob_thr option to training CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ python -m motor_det.engine.train \
 검증 단계에서 사용할 NMS 방식은 `nms_algorithm` 옵션으로 결정하며 기본값인 `vectorized` 모드는 탐지 개수가 `--nms_switch_thr`를 넘으면 자동으로 `greedy`로 전환됩니다.
 `--prob_thr` 값으로 NMS 전에 적용되는 최소 확률을 조절할 수 있으며 초기 학습 단계에서 너무 높은 임계값 때문에 탐지가 전혀 없을 경우 이 값을 낮추면 도움이 됩니다.
 
+예를 들어 임계값을 0.02로 지정하려면 다음과 같이 입력합니다:
+
+```bash
+python -m motor_det.engine.train \
+  --data_root <DATA_ROOT> \
+  --prob_thr 0.02
+```
+
 `--cpu_augment`를 사용하면 증강을 CPU에서 수행합니다. 이 경우 `--pin_memory`를 함께 지정하면 데이터 전송 속도를 높일 수 있습니다. 본 스크립트는 기본적으로 `persistent_workers=True`와 `prefetch_factor=2`를 사용해 데이터 로더 초기화를 최소화합니다. 필요하면 `--no-persistent_workers` 플래그로 끌 수 있습니다.
 
 슬라이딩 윈도우 추론 시에는 패치를 메모리 캐시에 저장해 중복 I/O를 줄입니다.

--- a/motor_det/config.py
+++ b/motor_det/config.py
@@ -81,7 +81,7 @@ class TrainingConfig:
     gpus: int = 1
     nms_algorithm: str = "vectorized"
     nms_switch_thr: int = 1500
-    prob_thr: float = 0.1
+    prob_thr: float = 0.02
     max_steps: int | None = None
     limit_val_batches: float | int = 1.0
     val_check_interval: float | int = 1.0
@@ -117,7 +117,7 @@ class InferenceConfig:
     num_tiles_w: int | None = None
     tile_xy: int | None = None
 
-    prob_thr: float = 0.6
+    prob_thr: float = 0.02
     sigma: float = 60.0
     iou_thr: float = 0.25
     default_spacing: float = DEFAULT_TEST_SPACING

--- a/motor_det/engine/lit_module.py
+++ b/motor_det/engine/lit_module.py
@@ -27,7 +27,7 @@ class LitMotorDet(L.LightningModule):
         total_steps: int = 30_000,
         nms_algorithm: str = "vectorized",
         nms_switch_thr: int = 1500,
-        prob_thr: float = 0.1,
+        prob_thr: float = 0.02,
         focal_gamma: float = 2.0,
         pos_weight_clip: float = 5.0,
     ):

--- a/motor_det/engine/train.py
+++ b/motor_det/engine/train.py
@@ -53,6 +53,8 @@ def cli() -> argparse.Namespace:
     p.add_argument("--val_check_interval", type=float, default=1.0)
     p.add_argument("--num_sanity_val_steps", type=int, default=0)
 
+    p.add_argument("--prob_thr", type=float, default=0.02)
+
     # misc
     p.add_argument("--gpus", type=int, default=1)
     p.add_argument("--transfer_weights", type=str, default=None)
@@ -92,6 +94,7 @@ def main() -> None:
         lr=args.lr,
         weight_decay=args.weight_decay,
         total_steps=total_steps,
+        prob_thr=args.prob_thr,
     )
     if args.transfer_weights:
         ckpt = torch.load(args.transfer_weights, map_location="cpu")

--- a/motor_det/postprocess/decoder.py
+++ b/motor_det/postprocess/decoder.py
@@ -38,7 +38,7 @@ def decode_detections(
     logits: torch.Tensor,         # (B,1,D,H,W)
     offsets: torch.Tensor,        # (B,3,D,H,W)
     stride: int = 2,
-    prob_thr: float = 0.6,
+    prob_thr: float = 0.02,
 ) -> List[torch.Tensor]:
     """
     배치-별 예측 좌표(Å) 리스트 반환
@@ -97,7 +97,7 @@ def decode_with_nms(
     logits: torch.Tensor,
     offsets: torch.Tensor,
     stride: int = 2,
-    prob_thr: float = 0.6,
+    prob_thr: float = 0.02,
     sigma: float = 60.0,
     iou_thr: float = 0.25,
     algorithm: str = "vectorized",

--- a/motor_det/tests/measure_performance.py
+++ b/motor_det/tests/measure_performance.py
@@ -38,7 +38,7 @@ def evaluate(weights: Path, data_root: Path, fold: int = 0) -> dict[str, float]:
                 out["cls"],
                 out["offset"],
                 stride=2,
-                prob_thr=0.6,
+                prob_thr=0.02,
                 sigma=60.0,
                 iou_thr=0.25,
             )[0]


### PR DESCRIPTION
## Summary
- expose `prob_thr` in training CLI
- pass `prob_thr` through to `LitMotorDet`
- document usage of `--prob_thr` flag
- set default probability threshold to 0.02 across training, inference and post-processing

## Testing
- `python -m py_compile motor_det/engine/train.py motor_det/engine/lit_module.py motor_det/config.py motor_det/engine/infer.py motor_det/postprocess/decoder.py motor_det/tests/measure_performance.py`
- `pytest -q` *(fails: command not found)*