### PR TITLE
Fix task assigner anchor dimension bug

### DIFF
--- a/motor_det/model/net.py
+++ b/motor_det/model/net.py
@@ -12,9 +12,14 @@ class MotorDetNet(nn.Module):
         super().__init__()
         self.backbone = MotorBackbone()
 
-        self.head_s4 = ObjectDetectionHead(64, 1, stride=4)
-        self.head_s8 = ObjectDetectionHead(128, 1, stride=8)
-        self.head_s16 = ObjectDetectionHead(256, 1, stride=16)
+        # Channel dimensions for the feature maps produced by ``MotorBackbone``
+        # are 32, 64 and 128 at strides 4, 8 and 16 respectively.  The detection
+        # heads were incorrectly initialised with doubled channel sizes which
+        # resulted in shape mismatch errors during training.  Initialise each
+        # head with the correct number of input channels.
+        self.head_s4 = ObjectDetectionHead(32, 1, stride=4)
+        self.head_s8 = ObjectDetectionHead(64, 1, stride=8)
+        self.head_s16 = ObjectDetectionHead(128, 1, stride=16)
 
     @property
     def strides(self):

--- a/motor_det/models/task_aligned_assigner.py
+++ b/motor_det/models/task_aligned_assigner.py
@@ -65,6 +65,12 @@ class TaskAlignedAssigner(nn.Module):
         batch_size, num_anchors, num_classes = pred_scores.shape
         _, num_max_boxes, _ = true_centers.shape
 
+        # ``anchor_points`` may be provided without a batch dimension.
+        # Expand to ``[B, N, 3]`` so shape expectations are consistent
+        # throughout the assignment routine.
+        if anchor_points.ndim == 2:
+            anchor_points = anchor_points.unsqueeze(0).expand(batch_size, -1, -1)
+
         if num_max_boxes == 0:
             assigned_labels = torch.full([batch_size, num_anchors], bg_index, dtype=torch.long, device=true_labels.device)
             assigned_points = torch.zeros([batch_size, num_anchors, 3], device=true_labels.device)


### PR DESCRIPTION
## Summary
- correct detection head channel initialization
- handle unbatched anchor_points inside `TaskAlignedAssigner`

## Testing
- `python motor_det/tests/test_quick_train.py` *(fails: ModuleNotFoundError: No module named 'lightning')*