### PR TITLE
Fix label mask broadcasting in detection loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,3 +186,17 @@ python -m motor_det.engine.train \
   --num_workers 0 --no-persistent_workers
 ```
 
+
+### CUDA 메모리 부족
+
+GPU 메모리가 8GB 정도로 제한된 경우 기본 설정으로는 학습 과정에서 `CUDA out of memory` 오류가 발생할 수 있습니다. 다음과 같이 배치 크기를 줄이고 증강을 CPU에서 수행하도록 하면 메모리 사용량을 크게 줄일 수 있습니다.
+
+```bash
+python -m motor_det.engine.train \
+  --data_root <DATA_ROOT> \
+  --batch_size 1 \
+  --cpu_augment
+```
+
+필요하다면 `--train_depth`, `--train_spatial` 같은 크기 관련 인자도 감소시켜 추가적인 메모리를 절약할 수 있습니다.
+

--- a/motor_det/loss/losses.py
+++ b/motor_det/loss/losses.py
@@ -183,16 +183,22 @@ def task_aligned_detection_loss(
         bg_index=0,
     )
 
-    label_mask = (lbl > 0).unsqueeze(-1)
-    cls_loss = varifocal_loss(pred_logits.squeeze(-1), tgt_scr.squeeze(-1), label_mask.float(), alpha=alpha, gamma=gamma)
+    label_mask = lbl > 0
+    cls_loss = varifocal_loss(
+        pred_logits.squeeze(-1),
+        tgt_scr.squeeze(-1),
+        label_mask.float(),
+        alpha=alpha,
+        gamma=gamma,
+    )
 
     if label_mask.any():
         diff2 = (pred_centers - tgt_ctr).pow(2).sum(dim=-1)
         iou = torch.exp(-diff2 / (2 * tgt_sigma**2))
-        iou_loss = (1 - iou[label_mask.squeeze(-1)]).mean()
+        iou_loss = (1 - iou[label_mask]).mean()
         l1 = F.smooth_l1_loss(
-            pred_centers[label_mask.squeeze(-1)],
-            tgt_ctr[label_mask.squeeze(-1)],
+            pred_centers[label_mask],
+            tgt_ctr[label_mask],
             reduction="mean",
         )
         reg_loss = iou_loss + l1


### PR DESCRIPTION
## Summary
- add a README section about dealing with CUDA out-of-memory errors
- fix label mask shape in `task_aligned_detection_loss`

## Testing
- `python motor_det/tests/test_quick_train.py` *(fails: ModuleNotFoundError: No module named 'lightning')*