### PR TITLE
Fix slowdown from random crop dataset

### DIFF
--- a/motor_det/config.py
+++ b/motor_det/config.py
@@ -66,7 +66,7 @@ class TrainingConfig:
     persistent_workers: bool = True
     positive_only: bool = False
     train_num_instance_crops: int = 128
-    train_num_random_crops: int = 128
+    train_num_random_crops: int = 0
     train_include_sliding_dataset: bool = False
     train_crop_size: tuple[int, int, int] = (96, 128, 128)
     valid_crop_size: tuple[int, int, int] = (192, 128, 128)

--- a/motor_det/data/module.py
+++ b/motor_det/data/module.py
@@ -35,7 +35,7 @@ class MotorDataModule(L.LightningDataModule):
         persistent_workers: bool = True,
         positive_only: bool = False,
         train_num_instance_crops: int = 128,
-        train_num_random_crops: int = 128,
+        train_num_random_crops: int = 0,
         train_include_sliding_dataset: bool = False,
         train_crop_size: tuple[int, int, int] = (96, 128, 128),
         valid_crop_size: tuple[int, int, int] = (192, 128, 128),
@@ -136,19 +136,22 @@ class MotorDataModule(L.LightningDataModule):
                         copy_paste_prob=self.copy_paste_prob,
                         copy_paste_limit=self.copy_paste_limit,
                     ),
-                    RandomCropDataset(
-                        zarr_path,
-                        centers,
-                        vx,
-                        crop_size=self.train_crop_size,
-                        num_crops=self.train_num_random_crops,
-                        use_gpu=use_gpu,
-                        mixup_prob=self.mixup_prob,
-                        cutmix_prob=self.cutmix_prob,
-                        copy_paste_prob=self.copy_paste_prob,
-                        copy_paste_limit=self.copy_paste_limit,
-                    ),
                 ]
+                if self.train_num_random_crops > 0:
+                    sub_datasets.append(
+                        RandomCropDataset(
+                            zarr_path,
+                            centers,
+                            vx,
+                            crop_size=self.train_crop_size,
+                            num_crops=self.train_num_random_crops,
+                            use_gpu=use_gpu,
+                            mixup_prob=self.mixup_prob,
+                            cutmix_prob=self.cutmix_prob,
+                            copy_paste_prob=self.copy_paste_prob,
+                            copy_paste_limit=self.copy_paste_limit,
+                        )
+                    )
                 if self.train_include_sliding_dataset:
                     sub_datasets.append(
                         SlidingWindowDataset(

--- a/motor_det/engine/train.py
+++ b/motor_det/engine/train.py
@@ -104,7 +104,7 @@ def cli() -> argparse.Namespace:
         help="only sample patches containing motors",
     )
     p.add_argument("--train_num_instance_crops", type=int, default=128)
-    p.add_argument("--train_num_random_crops", type=int, default=128)
+    p.add_argument("--train_num_random_crops", type=int, default=0)
     p.add_argument("--train_include_sliding_dataset", action=argparse.BooleanOptionalAction, default=False)
     p.add_argument("--cpu_augment", action="store_true")
     p.add_argument("--mixup", type=float, default=0.0)


### PR DESCRIPTION
## Summary
- avoid heavy random cropping by default
- only include `RandomCropDataset` when requested

## Testing
- `python -m py_compile motor_det/data/module.py motor_det/config.py motor_det/engine/train.py`