### PR TITLE
Add optional volume preloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ python -m motor_det.engine.train \
   --prob_thr 0.02
 ```
 
-`--cpu_augment`를 사용하면 증강을 CPU에서 수행합니다. 이 경우 `--pin_memory`를 함께 지정하면 데이터 전송 속도를 높일 수 있습니다. 본 스크립트는 기본적으로 `persistent_workers=True`와 `prefetch_factor=2`를 사용해 데이터 로더 초기화를 최소화합니다. 필요하면 `--no-persistent_workers` 플래그로 끌 수 있습니다.
+`--cpu_augment`를 사용하면 증강을 CPU에서 수행합니다. 이 경우 `--pin_memory`를 함께 지정하면 데이터 전송 속도를 높일 수 있습니다. 본 스크립트는 기본적으로 `persistent_workers=True`와 `prefetch_factor=2`를 사용해 데이터 로더 초기화를 최소화합니다. 필요하면 `--no-persistent_workers` 플래그로 끌 수 있습니다. 대역폭이 충분하다면 `--preload_volumes` 옵션을 통해 토모그램을 메모리로 미리 불러와 I/O 병목을 줄일 수 있습니다.
 
 모터가 없는 부정 패치도 함께 학습에 사용되며 이는 클래스 균형을 맞추는 데 도움이 됩니다. 만약 모터가 있는 영역만 사용하고 싶다면 `--positive_only` 플래그를 지정하세요.
 

--- a/motor_det/config.py
+++ b/motor_det/config.py
@@ -72,6 +72,7 @@ class TrainingConfig:
     valid_crop_size: tuple[int, int, int] = (192, 128, 128)
     pin_memory: bool = False
     prefetch_factor: int | None = 2
+    preload_volumes: bool = False
     use_gpu_augment: bool = True
     valid_use_gpu_augment: bool | None = False
     mixup_prob: float = 0.0

--- a/motor_det/data/detection/instance_crop_dataset.py
+++ b/motor_det/data/detection/instance_crop_dataset.py
@@ -29,6 +29,7 @@ class InstanceCropDataset(DetectionDataset, PatchCacheMixin):
         num_crops: int | None = 64,
         negative_ratio: float = 0.2,
         cache_size: int = 128,
+        preload_volume: bool = False,
         *,
         use_gpu: bool = True,
         mixup_prob: float = 0.0,
@@ -46,6 +47,8 @@ class InstanceCropDataset(DetectionDataset, PatchCacheMixin):
         )
         PatchCacheMixin.__init__(self, cache_size=cache_size)
         self.vol = zarr.open(zarr_path, mode="r")
+        if preload_volume:
+            self.vol = np.asarray(self.vol)
         self.centers = center_xyz.astype(np.float32) / voxel_spacing
         self.spacing = float(voxel_spacing)
         self.crop_size = crop_size

--- a/motor_det/data/detection/random_crop_dataset.py
+++ b/motor_det/data/detection/random_crop_dataset.py
@@ -26,6 +26,7 @@ class RandomCropDataset(DetectionDataset, PatchCacheMixin):
         crop_size: Tuple[int, int, int] = (96, 128, 128),
         num_crops: int = 64,
         cache_size: int = 128,
+        preload_volume: bool = False,
         *,
         use_gpu: bool = True,
         mixup_prob: float = 0.0,
@@ -43,6 +44,8 @@ class RandomCropDataset(DetectionDataset, PatchCacheMixin):
         )
         PatchCacheMixin.__init__(self, cache_size=cache_size)
         self.vol = zarr.open(zarr_path, mode="r")
+        if preload_volume:
+            self.vol = np.asarray(self.vol)
         self.centers = center_xyz.astype(np.float32) / voxel_spacing
         self.spacing = float(voxel_spacing)
         self.crop_size = crop_size

--- a/motor_det/data/detection/sliding_window_dataset.py
+++ b/motor_det/data/detection/sliding_window_dataset.py
@@ -56,8 +56,11 @@ class SlidingWindowDataset(PatchCacheMixin, Dataset, ObjectDetectionMixin):
         cache_size: int = 128,
         num_tiles: Tuple[int, int, int] | None = None,
         voxel_spacing: float = 1.0,
+        preload_volume: bool = False,
     ) -> None:
         self.store = zarr.open(zarr_path, mode="r")
+        if preload_volume:
+            self.store = np.asarray(self.store).astype(dtype)
         self.win = window
         self.window = window
         self.stride = stride

--- a/motor_det/data/module.py
+++ b/motor_det/data/module.py
@@ -41,6 +41,7 @@ class MotorDataModule(L.LightningDataModule):
         valid_crop_size: tuple[int, int, int] = (192, 128, 128),
         pin_memory: bool = False,
         prefetch_factor: int | None = 2,
+        preload_volumes: bool = False,
         use_gpu_augment: bool = True,
         valid_use_gpu_augment: bool | None = None,
         mixup_prob: float = 0.0,
@@ -59,6 +60,7 @@ class MotorDataModule(L.LightningDataModule):
         self.persistent_workers = persistent_workers
         self.pin_memory = pin_memory
         self.prefetch_factor = prefetch_factor
+        self.preload_volumes = preload_volumes
 
         # dataset 파라미터
         self.positive_only = bool(positive_only)
@@ -130,6 +132,7 @@ class MotorDataModule(L.LightningDataModule):
                         crop_size=self.train_crop_size,
                         num_crops=self.train_num_instance_crops,
                         negative_ratio=0.0 if self.positive_only else 0.2,
+                        preload_volume=self.preload_volumes,
                         use_gpu=use_gpu,
                         mixup_prob=self.mixup_prob,
                         cutmix_prob=self.cutmix_prob,
@@ -145,6 +148,7 @@ class MotorDataModule(L.LightningDataModule):
                             vx,
                             crop_size=self.train_crop_size,
                             num_crops=self.train_num_random_crops,
+                            preload_volume=self.preload_volumes,
                             use_gpu=use_gpu,
                             mixup_prob=self.mixup_prob,
                             cutmix_prob=self.cutmix_prob,
@@ -159,6 +163,7 @@ class MotorDataModule(L.LightningDataModule):
                             window=self.valid_crop_size,
                             stride=tuple(s // 2 for s in self.valid_crop_size),
                             voxel_spacing=vx,
+                            preload_volume=self.preload_volumes,
                         )
                     )
                 ds = ConcatDataset(sub_datasets)
@@ -170,6 +175,7 @@ class MotorDataModule(L.LightningDataModule):
                     crop_size=crop_size,
                     num_crops=self.val_num_crops,
                     negative_ratio=0.0 if self.positive_only else 0.2,
+                    preload_volume=self.preload_volumes,
                     use_gpu=use_gpu,
                     mixup_prob=0.0,
                     cutmix_prob=0.0,

--- a/motor_det/engine/train.py
+++ b/motor_det/engine/train.py
@@ -38,6 +38,7 @@ def train(cfg: TrainingConfig) -> L.Trainer:
         valid_crop_size=cfg.valid_crop_size,
         pin_memory=cfg.pin_memory,
         prefetch_factor=cfg.prefetch_factor,
+        preload_volumes=cfg.preload_volumes,
         use_gpu_augment=cfg.use_gpu_augment,
         valid_use_gpu_augment=cfg.valid_use_gpu_augment,
         mixup_prob=cfg.mixup_prob,
@@ -96,6 +97,7 @@ def cli() -> argparse.Namespace:
     p.add_argument("--persistent_workers", action=argparse.BooleanOptionalAction, default=True)
     p.add_argument("--pin_memory", action="store_true")
     p.add_argument("--prefetch_factor", type=int, default=2)
+    p.add_argument("--preload_volumes", action=argparse.BooleanOptionalAction, default=False)
 
     p.add_argument(
         "--positive_only",
@@ -156,6 +158,7 @@ def main() -> None:
         valid_crop_size=(args.valid_depth, args.valid_spatial, args.valid_spatial),
         pin_memory=args.pin_memory,
         prefetch_factor=args.prefetch_factor,
+        preload_volumes=args.preload_volumes,
         use_gpu_augment=not args.cpu_augment,
         valid_use_gpu_augment=False,
         mixup_prob=args.mixup,


### PR DESCRIPTION
## Summary
- optionally load tomograms into memory to avoid I/O
- expose `preload_volumes` through config and CLI
- document the option

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python motor_det/tests/test_quick_train.py` *(fails: `ModuleNotFoundError: No module named 'lightning'`)*