### PR TITLE
Enable preload by default and speed up sampling

### DIFF
--- a/motor_det/config.py
+++ b/motor_det/config.py
@@ -72,7 +72,7 @@ class TrainingConfig:
     valid_crop_size: tuple[int, int, int] = (192, 128, 128)
     pin_memory: bool = False
     prefetch_factor: int | None = 2
-    preload_volumes: bool = False
+    preload_volumes: bool = True
     use_gpu_augment: bool = True
     valid_use_gpu_augment: bool | None = False
     mixup_prob: float = 0.0

--- a/motor_det/data/detection/instance_crop_dataset.py
+++ b/motor_det/data/detection/instance_crop_dataset.py
@@ -63,10 +63,34 @@ class InstanceCropDataset(DetectionDataset, PatchCacheMixin):
         return self.num_crops
 
     # sampling utilities -------------------------------------------------
+    def _compute_positive_start(self, center: np.ndarray, jitter: int = 8) -> tuple[int, int, int]:
+        """Calculate a jittered crop start around ``center`` without loading data."""
+        D, H, W = self.crop_size
+        Z, Y, X = self.vol.shape
+
+        ctr = center.astype(float)
+        if jitter:
+            ctr += np.random.randint(-jitter, jitter + 1, size=3)
+
+        start = ctr[[2, 1, 0]] - np.array(self.crop_size) / 2
+        start = np.round(start).astype(int)
+        start = np.clip(start, 0, np.maximum(0, np.array([Z - D, Y - H, X - W])))
+
+        end = start + np.array(self.crop_size)
+        cz, cy, cx = center[2], center[1], center[0]
+        if not (start[0] <= cz < end[0]):
+            start[0] = int(np.clip(cz - D // 2, 0, max(0, Z - D)))
+        if not (start[1] <= cy < end[1]):
+            start[1] = int(np.clip(cy - H // 2, 0, max(0, Y - H)))
+        if not (start[2] <= cx < end[2]):
+            start[2] = int(np.clip(cx - W // 2, 0, max(0, X - W)))
+        return tuple(start)
+
     def _sample_positive(self):
         idx = np.random.randint(len(self.centers))
         ctr = self.centers[idx]
-        patch, start = random_crop_around_point(self.vol, ctr, self.crop_size)
+        start = self._compute_positive_start(ctr)
+        patch = self._load_patch_cached(self.vol, start, self.crop_size)
         return patch, start
 
     def _sample_negative(self):

--- a/motor_det/data/module.py
+++ b/motor_det/data/module.py
@@ -41,7 +41,7 @@ class MotorDataModule(L.LightningDataModule):
         valid_crop_size: tuple[int, int, int] = (192, 128, 128),
         pin_memory: bool = False,
         prefetch_factor: int | None = 2,
-        preload_volumes: bool = False,
+        preload_volumes: bool = True,
         use_gpu_augment: bool = True,
         valid_use_gpu_augment: bool | None = None,
         mixup_prob: float = 0.0,

--- a/motor_det/engine/train.py
+++ b/motor_det/engine/train.py
@@ -5,7 +5,8 @@ Minimal BYU-Motor training runner
 python -m motor_det.engine.train ^
        --data_root D:\abs\path\data ^
        --batch_size 2 ^
-       --epochs 10
+       --epochs 10 ^
+       --preload_volumes
 """
 from __future__ import annotations
 import argparse
@@ -97,7 +98,7 @@ def cli() -> argparse.Namespace:
     p.add_argument("--persistent_workers", action=argparse.BooleanOptionalAction, default=True)
     p.add_argument("--pin_memory", action="store_true")
     p.add_argument("--prefetch_factor", type=int, default=2)
-    p.add_argument("--preload_volumes", action=argparse.BooleanOptionalAction, default=False)
+    p.add_argument("--preload_volumes", action=argparse.BooleanOptionalAction, default=True)
 
     p.add_argument(
         "--positive_only",

--- a/motor_det/tests/measure_performance.py
+++ b/motor_det/tests/measure_performance.py
@@ -17,6 +17,7 @@ def evaluate(weights: Path, data_root: Path, fold: int = 0) -> dict[str, float]:
         batch_size=1,
         num_workers=12,
         persistent_workers=True,
+        preload_volumes=False,
         use_gpu_augment=False,
         valid_use_gpu_augment=False,
     )

--- a/motor_det/tests/test_quick_train.py
+++ b/motor_det/tests/test_quick_train.py
@@ -22,6 +22,7 @@ dm = MotorDataModule(
     batch_size=1,
     num_workers=12,
     persistent_workers=True,
+    preload_volumes=False,
     valid_use_gpu_augment=False,
     pin_memory=True,
 )

--- a/quick_train_val.py
+++ b/quick_train_val.py
@@ -23,6 +23,7 @@ cfg = TrainingConfig(
     valid_use_gpu_augment=False,
     pin_memory=True,
     prefetch_factor=2,
+    preload_volumes=True,
     epochs=10,
     max_steps=1500,
     val_check_interval=1500,


### PR DESCRIPTION
## Summary
- set `preload_volumes=True` by default across config, datamodule and CLI
- cache positive sampling to avoid extra I/O
- show recommended preload flag in quick_train and docs
- keep tests functional by disabling preloading

## Testing
- `pre-commit` *(fails: command not found)*